### PR TITLE
Pushing annotations of bodyids

### DIFF
--- a/clio/annotate.py
+++ b/clio/annotate.py
@@ -7,7 +7,7 @@ from .client import inject_client
 CLIO_TEST_STORE = 'https://clio-test-7fdj77ed7q-uk.a.run.app'
 
 @inject_client
-def annotate_bodyids(annotations, test=True, client=None):
+def annotate_bodyids(annotations, test=True, *, client=None):
     """Annotate bodyIDs.
 
     If no limiting criteria are given will return all available annotations.
@@ -38,8 +38,9 @@ def annotate_bodyids(annotations, test=True, client=None):
         raise ValueError("annotations DataFrame must contain a `bodyid` column")
     url_template = f"v2/json-annotations/{client.dataset}/neurons"
     url = client.make_url(url_template)
-    status = client._fetch(url, json=annotations.to_json(orient='records'), ispost=True)
+    status = client._fetch(url, json=annotations.to_dict(orient='records'), ispost=True)
     if test: client.server = prev_store
-    return status
+    if status.ok:
+        print("Bodyids annotated successfully.")
 
 

--- a/clio/annotate.py
+++ b/clio/annotate.py
@@ -17,8 +17,9 @@ def annotate_bodyids(annotations, test=True, *, client=None):
     annotations : pd.DataFrame
                 DataFrame with bodyid annotations, must have a `bodyid` column.
 
-    test : bool
-                Whether to send annotations to test or production server.
+    test        : bool
+                Whether to send annotations to test (True) or production (False) server.
+                Set to False only if you know what you are doing.
 
     Examples
     --------

--- a/clio/annotate.py
+++ b/clio/annotate.py
@@ -1,0 +1,45 @@
+import warnings
+
+import pandas as pd
+
+from .client import inject_client
+
+CLIO_TEST_STORE = 'https://clio-test-7fdj77ed7q-uk.a.run.app'
+
+@inject_client
+def annotate_bodyids(annotations, test=True, client=None):
+    """Annotate bodyIDs.
+
+    If no limiting criteria are given will return all available annotations.
+
+    Parameters
+    ----------
+    annotations : pd.DataFrame
+                DataFrame with bodyid annotations, must have a `bodyid` column.
+
+    test : bool
+                Whether to send annotations to test or production server.
+
+    Examples
+    --------
+    Fetch annotations for a single body
+    >>> dummy_annots = pd.DataFrame.from_records({'bodyid':[10000, 14132], 'b':[44,66]})
+    >>> annotate_bodyids(dummy_annots)
+    """
+
+    if test:
+        prev_store = client.server
+        if client.server !=  CLIO_TEST_STORE:    
+            client.server = CLIO_TEST_STORE
+        warnings.warn("Pushing data annotations to the test store.")
+    if not isinstance(annotations, pd.DataFrame):
+        raise TypeError("Annotations must be a pandas.DataFrame")
+    if not 'bodyid' in annotations.columns:
+        raise ValueError("annotations DataFrame must contain a `bodyid` column")
+    url_template = f"v2/json-annotations/{client.dataset}/neurons"
+    url = client.make_url(url_template)
+    status = client._fetch(url, json=annotations.to_json(orient='records'), ispost=True)
+    if test: client.server = prev_store
+    return status
+
+

--- a/clio/client.py
+++ b/clio/client.py
@@ -37,7 +37,6 @@ CLIO_CLIENTS = {}
 CLIO_TOKEN_FILE = '~/clio_token.json'
 CLIO_TOKEN_URL = 'https://clio-store-vwzoicitea-uk.a.run.app/v2/server/token'
 
-
 def default_client():
     """
     Obtain the default Client object to use.

--- a/clio/client.py
+++ b/clio/client.py
@@ -37,6 +37,7 @@ CLIO_CLIENTS = {}
 CLIO_TOKEN_FILE = '~/clio_token.json'
 CLIO_TOKEN_URL = 'https://clio-store-vwzoicitea-uk.a.run.app/v2/server/token'
 
+
 def default_client():
     """
     Obtain the default Client object to use.


### PR DESCRIPTION
The `annotate_bodyids` pushes our the bodyid annotations from a DataFrame to a Clio store.

Similarly to R implementation, to avoid potential errors, by default this pushes to TEST store, and informs user about the status of the query, then a user can decide to push it to production.